### PR TITLE
remove deprecation warnings when used with Rails 3.2.X

### DIFF
--- a/lib/rails_helper.rb
+++ b/lib/rails_helper.rb
@@ -54,8 +54,6 @@ class Helper < (defined?(ActionView::Base) ? ActionView::Base : Object)
     response = ActionDispatch::TestResponse.new
     controller.request = request
     controller.response = response
-    controller.send(:initialize_template_class, response)
-    controller.send(:assign_shortcuts, request, response)
     controller.send(:default_url_options).merge!(DefaultUrlOptions) if defined?(DefaultUrlOptions)
     controller
   end


### PR DESCRIPTION
For example:

```
DEPRECATION WARNING: Calling `initialize_template_class` is deprecated and has no effect anymore.
DEPRECATION WARNING: Calling `assign_shortcuts` is deprecated and has no effect anymore.
```

I recommend a significant version bump as this may break compatibility with earlier versions of Rails
